### PR TITLE
Add k6 tests

### DIFF
--- a/test/load/README.md
+++ b/test/load/README.md
@@ -1,0 +1,34 @@
+# K6 Load Testing for Hederium
+
+This directory contains k6 scripts and related configuration for load testing the Hederium JSON-RPC endpoints.
+
+## Overview
+
+- **Scripts Directory (`./scripts/`):** Contains individual test scripts for various JSON-RPC methods (e.g. `eth_blockNumber_test.js`).
+- **Common Utilities (`./common.js`):** Provides shared configuration and helper functions for all test scripts.
+- **Scenarios Directory (`./scenarios/`):** (Optional) Contains advanced scenario configurations for complex load patterns.
+- **Environment Variables:** Used to control endpoint URLs, API keys, and load parameters without changing scripts.
+
+## Prerequisites
+
+- [k6](https://k6.io/) installed on your machine.
+- The Hederium service running locally or accessible at the configured URL.
+
+## Configuration
+
+You can control the behavior of the tests using environment variables:
+
+- **ENDPOINT_URL:** The URL of your JSON-RPC endpoint. Default is `http://localhost:7546`.
+- **API_KEY:** The API key to send in the `X-API-KEY` header, if needed. Leave empty if not required.
+- **VUS:** Number of Virtual Users (VUs) to simulate. Default is `1`.
+- **DURATION:** Test duration (e.g. `10s`, `30s`, `1m`). Default is `10s`.
+
+Example:
+
+```bash
+ENDPOINT_URL=http://localhost:7546 \
+API_KEY=FREE-USER-API-KEY-123 \
+VUS=10 \
+DURATION=30s \
+k6 run ./scripts/eth_blockNumber_test.js
+```

--- a/test/load/k6/common.js
+++ b/test/load/k6/common.js
@@ -1,0 +1,29 @@
+import { check } from "k6";
+
+export function getEnvVar(name, defaultValue) {
+  const value = __ENV[name];
+  return value === undefined || value === "" ? defaultValue : value;
+}
+
+// Load configuration from environment variables with defaults
+export const config = {
+  endpoint: getEnvVar("ENDPOINT_URL", "http://localhost:7546"),
+  apiKey: getEnvVar("API_KEY", ""), // empty means no key required
+  vus: parseInt(getEnvVar("VUS", "1"), 10),
+  duration: getEnvVar("DURATION", "10s"),
+};
+
+// A basic check function for JSON-RPC responses
+export function validateJsonRpcResponse(response, methodExpected) {
+  return check(response, {
+    "status is 200": (r) => r.status === 200,
+    "jsonrpc is 2.0": (r) => {
+      const body = r.json();
+      return body.jsonrpc === "2.0";
+    },
+    [`method ${methodExpected} result`]: (r) => {
+      const body = r.json();
+      return body.result !== undefined;
+    },
+  });
+}

--- a/test/load/k6/scenarios/eth_blockNumber_scenario.js
+++ b/test/load/k6/scenarios/eth_blockNumber_scenario.js
@@ -1,0 +1,14 @@
+import { config } from "../common.js";
+
+export let options = {
+  vus: config.vus,
+  duration: config.duration,
+  thresholds: {
+    http_req_duration: ["p(95)<500"], // 95th percentile under 500ms
+  },
+  stages: [
+    { duration: "10s", target: 5 },
+    { duration: "20s", target: 10 },
+    { duration: "10s", target: 5 },
+  ],
+};

--- a/test/load/k6/scripts/eth_blockNumber_test.js
+++ b/test/load/k6/scripts/eth_blockNumber_test.js
@@ -1,0 +1,35 @@
+import http from "k6/http";
+import { check } from "k6";
+import { config, validateJsonRpcResponse } from "../common.js";
+
+export let options = {
+  vus: config.vus,
+  duration: config.duration,
+};
+
+export default function () {
+  const payload = JSON.stringify({
+    jsonrpc: "2.0",
+    method: "eth_blockNumber",
+    params: [],
+    id: 1,
+  });
+
+  const headers = { "Content-Type": "application/json" };
+  if (config.apiKey) {
+    headers["X-API-KEY"] = config.apiKey;
+  }
+
+  const res = http.post(config.endpoint, payload, { headers: headers });
+
+  // Validate common JSON-RPC structure
+  const passed = validateJsonRpcResponse(res, "eth_blockNumber");
+
+  // Additional checks can be done here
+  check(res, {
+    "result is a hex string": (r) => {
+      const body = r.json();
+      return typeof body.result === "string" && body.result.startsWith("0x");
+    },
+  });
+}


### PR DESCRIPTION
### Summary:
This PR introduces a k6-based load testing framework for the Hederium application’s JSON-RPC endpoints. We’ve added a structured test environment, leveraged environment variables for configuration, and established best practices for writing, running, and maintaining load tests.

### Key Changes:

Added a new test/load/k6 directory containing:
common.js: A shared utilities and configuration file that loads environment variables and provides helper functions for JSON-RPC response validation.
scripts/eth_blockNumber_test.js: An initial k6 test script targeting the eth_blockNumber endpoint.
Support for environment variables (ENDPOINT_URL, API_KEY, VUS, DURATION) to control test parameters without modifying code.
Documentation (README.md) added under test/load/ explaining how to run and expand load tests.
Example checks included to validate JSON-RPC structure and output correctness.
Future Work:

Add more test scripts for other JSON-RPC methods.
Integrate scenarios for more complex load patterns (e.g. ramping patterns, thresholds).
