### PR TITLE
Add net service

### DIFF
--- a/internal/service/net_service.go
+++ b/internal/service/net_service.go
@@ -1,0 +1,30 @@
+package service
+
+import "go.uber.org/zap"
+
+type Net interface {
+	Listening() bool
+	Version() string
+}
+
+type NetService struct {
+	log     *zap.Logger
+	chainId string
+}
+
+func NewNetService(log *zap.Logger, chainId string) *NetService {
+	return &NetService{
+		log:     log,
+		chainId: chainId,
+	}
+}
+
+// Listening returns false because the Hedera network does not support listening.
+func (n *NetService) Listening() bool {
+	return false
+}
+
+// Version returns the chain ID.
+func (n *NetService) Version() string {
+	return n.chainId
+}

--- a/internal/transport/http_handler.go
+++ b/internal/transport/http_handler.go
@@ -58,6 +58,10 @@ func dispatchMethod(ctx *gin.Context, methodName string, params interface{}) (in
 		return ethService.GetAccounts()
 	case "web3_clientVersion":
 		return web3Service.ClientVersion(), nil
+	case "net_listening":
+		return netService.Listening(), nil
+	case "net_version":
+		return netService.Version(), nil
 	case "eth_syncing":
 		return ethService.Syncing()
 	case "eth_mining":

--- a/internal/transport/rpc_router.go
+++ b/internal/transport/rpc_router.go
@@ -11,6 +11,7 @@ import (
 
 var ethService *service.EthService
 var web3Service *service.Web3Service
+var netService *service.NetService
 var logger *zap.Logger
 
 func SetupRouter(
@@ -26,6 +27,8 @@ func SetupRouter(
 	logger = log
 	ethService = service.NewEthService(hClient, mClient, log, tieredLimiter, chainId)
 	web3Service = service.NewWeb3Service(log, applicationVersion)
+	netService = service.NewNetService(log, chainId)
+
 	router := gin.Default()
 
 	if enforceAPIKey {

--- a/test/load/k6/scenarios/net_service_scenario.js
+++ b/test/load/k6/scenarios/net_service_scenario.js
@@ -1,0 +1,38 @@
+export const netServiceScenario = {
+  net_service_smoke: {
+    executor: "constant-vus",
+    vus: 1,
+    duration: "30s",
+  },
+  net_service_load: {
+    executor: "ramping-vus",
+    startVUs: 1,
+    stages: [
+      { duration: "30s", target: 20 },
+      { duration: "1m", target: 20 },
+      { duration: "30s", target: 0 },
+    ],
+    gracefulRampDown: "30s",
+  },
+  net_service_stress: {
+    executor: "ramping-vus",
+    startVUs: 20,
+    stages: [
+      { duration: "2m", target: 50 },
+      { duration: "5m", target: 50 },
+      { duration: "2m", target: 0 },
+    ],
+    gracefulRampDown: "30s",
+  },
+  net_service_soak: {
+    executor: "constant-vus",
+    vus: 10,
+    duration: "30m",
+  },
+};
+
+export const netServiceThresholds = {
+  http_req_duration: ["p(95)<500"], // 95% of requests should be below 500ms
+  http_req_failed: ["rate<0.01"], // Less than 1% of requests should fail
+  http_reqs: ["rate>100"], // Should maintain at least 100 RPS
+};

--- a/test/load/k6/scripts/net_service_test.js
+++ b/test/load/k6/scripts/net_service_test.js
@@ -1,0 +1,29 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import {
+  netServiceScenario,
+  netServiceThresholds,
+} from "../scenarios/net_service_scenario.js";
+
+export const options = {
+  scenarios: netServiceScenario,
+  thresholds: netServiceThresholds,
+};
+
+export default function () {
+  // Test listening endpoint
+  const listeningRes = http.get("http://localhost:8545/net/listening");
+  check(listeningRes, {
+    "listening status is 200": (r) => r.status === 200,
+    "listening returns false": (r) => r.json().result === false,
+  });
+
+  // Test version endpoint
+  const versionRes = http.get("http://localhost:8545/net/version");
+  check(versionRes, {
+    "version status is 200": (r) => r.status === 200,
+    "version is not empty": (r) => r.json().result.length > 0,
+  });
+
+  sleep(1);
+}

--- a/test/unit/service/net_service_test.go
+++ b/test/unit/service/net_service_test.go
@@ -1,0 +1,35 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/georgi-l95/Hederium/internal/service"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestNetService_Listening(t *testing.T) {
+	// Setup
+	logger := zap.NewNop()
+	chainId := "testnet-123"
+	netService := service.NewNetService(logger, chainId)
+
+	// Test
+	result := netService.Listening()
+
+	// Assert
+	assert.False(t, result, "Listening should always return false for Hedera network")
+}
+
+func TestNetService_Version(t *testing.T) {
+	// Setup
+	logger := zap.NewNop()
+	expectedChainId := "testnet-123"
+	netService := service.NewNetService(logger, expectedChainId)
+
+	// Test
+	result := netService.Version()
+
+	// Assert
+	assert.Equal(t, expectedChainId, result, "Version should return the chain ID")
+}


### PR DESCRIPTION
# Net Service Implementation

This PR introduces the Net Service implementation for the Hedera JSON-RPC API, following the Ethereum JSON-RPC specification for the `net` namespace.

## Changes
- Added `NetService` implementation with two methods:
  - `Listening()`: Always returns `false` as Hedera doesn't support network listening
  - `Version()`: Returns the chain ID of the network

## Testing
### Unit Tests
Added comprehensive unit tests for the `NetService`:
- Test cases for `Listening()` method verifying it always returns `false`
- Test cases for `Version()` method ensuring correct chain ID is returned

### Load Testing
Implemented k6 load testing suite with multiple scenarios:
- **Smoke Test**: Basic validation with 1 VU for 30s
- **Load Test**: Gradual ramp-up to 20 VUs over 30s, maintaining for 1m
- **Stress Test**: Heavy load testing with up to 50 VUs over 9m
- **Soak Test**: Long-running test with 10 VUs for 30m

Performance thresholds:
- 95% of requests complete under 500ms
- Less than 1% error rate
- Minimum throughput of 100 RPS

## API Endpoints
- `net_listening`: Returns network listening status
- `net_version`: Returns the current network's chain ID

Fixes #15 
Fixes #16 