### PR TITLE
Add eth_getTransactionCount endpoint

### DIFF
--- a/test/load/k6/scenarios/eth_getTransactionCount_scenario.js
+++ b/test/load/k6/scenarios/eth_getTransactionCount_scenario.js
@@ -1,0 +1,47 @@
+import { getTransactionCount } from "../scripts/eth_getTransactionCount_test.js";
+
+export const options = {
+  scenarios: {
+    constant_load: {
+      executor: "constant-vus",
+      vus: 10,
+      duration: "30s",
+      gracefulStop: "5s",
+    },
+    stress_test: {
+      executor: "ramping-vus",
+      startVUs: 0,
+      stages: [
+        { duration: "20s", target: 20 },
+        { duration: "30s", target: 20 },
+        { duration: "20s", target: 0 },
+      ],
+      gracefulRampDown: "5s",
+    },
+    spike_test: {
+      executor: "ramping-arrival-rate",
+      startRate: 0,
+      timeUnit: "1s",
+      preAllocatedVUs: 50,
+      maxVUs: 100,
+      stages: [
+        { duration: "10s", target: 10 },
+        { duration: "1m", target: 10 },
+        { duration: "10s", target: 100 },
+        { duration: "3m", target: 100 },
+        { duration: "10s", target: 10 },
+        { duration: "3m", target: 10 },
+        { duration: "10s", target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    http_req_duration: ["p(95)<500"],
+    http_req_failed: ["rate<0.01"],
+    errors: ["count<100"],
+  },
+};
+
+export default function () {
+  getTransactionCount();
+}

--- a/test/load/k6/scripts/eth_getTransactionCount_test.js
+++ b/test/load/k6/scripts/eth_getTransactionCount_test.js
@@ -1,0 +1,39 @@
+import { check } from "k6";
+import http from "k6/http";
+import { Counter } from "k6/metrics";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { getBaseUrl, getDefaultHeaders } from "../common.js";
+
+const errors = new Counter("errors");
+
+export function getTransactionCount() {
+  const baseUrl = getBaseUrl();
+  const headers = getDefaultHeaders();
+  const address = "0x117EE00a3191499e816068b10b4BE78DEEd74087";
+  const blockParams = ["latest", "earliest", "pending", "0x1", "0x100"];
+  const blockParam = blockParams[randomIntBetween(0, blockParams.length - 1)];
+
+  const payload = {
+    jsonrpc: "2.0",
+    method: "eth_getTransactionCount",
+    params: [address, blockParam],
+    id: 1,
+  };
+
+  const response = http.post(baseUrl, JSON.stringify(payload), { headers });
+
+  const success = check(response, {
+    "status is 200": (r) => r.status === 200,
+    "has result": (r) => r.json().result !== undefined,
+    "no error": (r) => r.json().error === undefined,
+    "valid hex": (r) => /^0x[0-9a-fA-F]+$/.test(r.json().result),
+    "valid nonce format": (r) => parseInt(r.json().result, 16) >= 0,
+  });
+
+  if (!success) {
+    console.log(`Error in getTransactionCount: ${response.body}`);
+    errors.add(1);
+  }
+
+  return response;
+}


### PR DESCRIPTION
This PR makes the following changes:
- Adds eth_getTransactionCount endpoint
- Adds new methods in the mirror-node-client
- Adds respective Unit and K6 Tests