### PR TITLE
feat: add helm charts for deployment

### DIFF
--- a/charts/.helmignore
+++ b/charts/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+appVersion: "0.0.1"
+type: application
+version: 0.1.0
+name: hederium
+description: A Helm chart for Hederium
+home: https://github.com/LimeChain/Hederium
+keywords:
+- hederium
+- json-rpc-relay
+- hedera

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,173 @@
+# Hederium Helm Chart
+
+This directory contains the Helm chart for deploying Hederium, a Hedera JSON-RPC relay service, to Kubernetes.
+
+## Chart Overview
+
+The Hederium chart deploys the following Kubernetes resources:
+
+- **Deployment**: Runs the Hederium application with the specified number of replicas
+- **Service**: Exposes the application via a LoadBalancer
+- **ConfigMap**: Stores the application configuration
+- **ServiceAccount**: Identity for the application pods
+
+Optional components (disabled by default):
+- **HorizontalPodAutoscaler**: Automatically scales the application based on CPU usage
+- **Ingress**: Provides advanced routing capabilities
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+- Minikube (for local deployment)
+- Docker
+
+## Deploying to Minikube
+
+### 1. Start Minikube
+
+```bash
+minikube start --cpus=2 --memory=4096 --disk-size=20g
+```
+
+### 2. Build the Docker Image in Minikube
+
+```bash
+# Configure your terminal to use Minikube's Docker daemon
+eval $(minikube docker-env)
+
+# Build the image
+docker build -t hederium:latest ../
+```
+
+### 3. Install the Helm Chart
+
+```bash
+# From the root of the repository
+helm install hederium ./charts
+```
+
+### 4. Access the Application
+
+Since we're using a LoadBalancer service in Minikube, you need to run:
+
+```bash
+# In a separate terminal window
+minikube tunnel
+```
+
+Then get the service URL:
+
+```bash
+kubectl get svc hederium
+```
+
+Or use the Minikube service command:
+
+```bash
+minikube service hederium --url
+```
+
+## Configuration
+
+### Key Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of replicas | `2` |
+| `image.repository` | Image repository | `hederium` |
+| `image.tag` | Image tag | `latest` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `service.type` | Service type | `LoadBalancer` |
+| `service.port` | Service port | `7546` |
+| `autoscaling.enabled` | Enable autoscaling | `false` |
+| `ingress.enabled` | Enable ingress | `false` |
+| `config.environment` | Application environment | `development` |
+| `config.hedera.network` | Hedera network | `testnet` |
+
+### Custom Values
+
+To override default values, create a custom values file:
+
+```yaml
+# custom-values.yaml
+replicaCount: 3
+config:
+  environment: "production"
+  hedera:
+    network: "mainnet"
+```
+
+Then install/upgrade with:
+
+```bash
+helm install hederium ./charts -f custom-values.yaml
+# or
+helm upgrade hederium ./charts -f custom-values.yaml
+```
+
+## Monitoring and Debugging
+
+### View Pods
+
+```bash
+kubectl get pods -l app.kubernetes.io/instance=hederium
+```
+
+### Check Logs
+
+```bash
+kubectl logs -l app.kubernetes.io/instance=hederium
+```
+
+### Using K9s
+
+For a better terminal UI experience, install and use K9s:
+
+```bash
+# Install K9s
+brew install k9s  # macOS
+# or
+sudo snap install k9s  # Linux
+
+# Run K9s
+k9s
+```
+
+Note: To see CPU and memory metrics in K9s, enable the metrics-server in Minikube:
+
+```bash
+minikube addons enable metrics-server
+```
+
+## Uninstalling the Chart
+
+```bash
+helm uninstall hederium
+```
+
+## Upgrading the Chart
+
+```bash
+# After making changes to the application
+eval $(minikube docker-env)
+docker build -t hederium:latest ../
+
+# Upgrade the Helm release
+helm upgrade hederium ./charts
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Image pull errors**: Ensure you've built the image in Minikube's Docker environment.
+2. **Service shows `<pending>`**: Run `minikube tunnel` in a separate terminal.
+3. **Configuration issues**: Check the logs to see if the application is reading the config correctly.
+4. **N/A metrics in K9s**: Enable the metrics-server addon in Minikube.
+
+For more help, check the application logs or describe the pods:
+
+```bash
+kubectl describe pod -l app.kubernetes.io/instance=hederium
+``` 

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "hederium.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "hederium.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "hederium.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "hederium.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hederium.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "hederium.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hederium.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "hederium.labels" -}}
+helm.sh/chart: {{ include "hederium.chart" . }}
+{{ include "hederium.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "hederium.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hederium.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "hederium.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "hederium.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "hederium.fullname" . }}-config
+  labels:
+    {{- include "hederium.labels" . | nindent 4 }}
+data:
+  config.yaml: |-
+    environment: {{ .Values.config.environment | quote }}
+    
+    application:
+      version: {{ .Values.config.application.version | quote }}
+    
+    server:
+      port: {{ .Values.config.server.port }}
+    
+    hedera:
+      network: {{ .Values.config.hedera.network | quote }}
+      operatorId: {{ .Values.config.hedera.operatorId | quote }}
+      operatorKey: {{ .Values.config.hedera.operatorKey | quote }}
+      chainId: {{ .Values.config.hedera.chainId | quote }}
+      hbarBudget: {{ .Values.config.hedera.hbarBudget | quote }}
+    
+    mirrorNode:
+      baseUrl: {{ .Values.config.mirrorNode.baseUrl | quote }}
+      timeoutSeconds: {{ .Values.config.mirrorNode.timeoutSeconds | quote }}
+    
+    limiter:
+      free:
+        requestsPerMinute: {{ .Values.config.limiter.free.requestsPerMinute | quote }}
+        hbarLimit: {{ .Values.config.limiter.free.hbarLimit | quote }}
+      premium:
+        requestsPerMinute: {{ .Values.config.limiter.premium.requestsPerMinute | quote }}
+        hbarLimit: {{ .Values.config.limiter.premium.hbarLimit | quote }}
+    
+    logging:
+      level: {{ .Values.config.logging.level | quote }}
+      DisableCaller: {{ .Values.config.logging.DisableCaller | quote }}
+    
+    apiKeys:
+      {{- range .Values.config.apiKeys }}
+      - key: {{ .key | quote }}
+        tier: {{ .tier | quote }}
+      {{- end }}
+    
+    features:
+      enforceApiKey: {{ .Values.config.features.enforceApiKey }}
+    
+    cache:
+      defaultExpiration: {{ .Values.config.cache.defaultExpiration | quote }}
+      cleanupInterval: {{ .Values.config.cache.cleanupInterval | quote }}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "hederium.fullname" . }}
+  labels:
+    {{- include "hederium.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "hederium.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "hederium.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "hederium.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          volumeMounts:
+            - name: config-volume
+              mountPath: /app/configs
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "hederium.fullname" . }}-config

--- a/charts/templates/hpa.yaml
+++ b/charts/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "hederium.fullname" . }}
+  labels:
+    {{- include "hederium.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "hederium.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/templates/ingress.yaml
+++ b/charts/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "hederium.fullname" . }}
+  labels:
+    {{- include "hederium.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "hederium.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hederium.fullname" . }}
+  labels:
+    {{- include "hederium.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "hederium.selectorLabels" . | nindent 4 }}

--- a/charts/templates/serviceaccount.yaml
+++ b/charts/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hederium.serviceAccountName" . }}
+  labels:
+    {{- include "hederium.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/templates/tests/test-connection.yaml
+++ b/charts/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "hederium.fullname" . }}-test-connection"
+  labels:
+    {{- include "hederium.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "hederium.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,96 @@
+# Default values for hederium
+replicaCount: 2
+
+image: 
+  repository: hederium
+  tag: latest
+  pullPolicy: Never
+
+service:
+  type: LoadBalancer
+  port: 7546
+
+# Add ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# Add autoscaling configuration
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 512Mi
+
+serviceAccount:
+  create: true  # Create the ServiceAccount
+  automount: true
+  annotations: {}
+  name: ""
+  
+# Application configuration
+config:
+  environment: "development"
+  
+  application:
+    version: "0.1.0"
+  
+  server:
+    port: 7546
+  
+  hedera:
+    network: "testnet"
+    operatorId: "0.0.1466"
+    operatorKey: "302e020100300506032b6570042204206bb5ca5c9a33b8a12e2d962fe14587fa40e92306e9c39bcd2bb62951100d7248"
+    chainId: "0x128"
+    hbarBudget: 1000
+  
+  mirrorNode:
+    baseUrl: "https://testnet.mirrornode.hedera.com"
+    timeoutSeconds: 10
+  
+  limiter:
+    free:
+      requestsPerMinute: 100
+      hbarLimit: 10
+    premium:
+      requestsPerMinute: 1000
+      hbarLimit: 10000
+  
+  logging:
+    level: "debug"
+    DisableCaller: true
+  
+  apiKeys:
+    - key: "FREE-USER-API-KEY-123"
+      tier: "free"
+    - key: "PREMIUM-USER-API-KEY-456"
+      tier: "premium"
+  
+  features:
+    enforceApiKey: false
+  
+  cache:
+    defaultExpiration: "1h"
+    cleanupInterval: "30m"


### PR DESCRIPTION
### Description

This PR adds Helm charts for deploying Hederium to Kubernetes environments, with a focus on local development using Minikube. The charts provide a standardized way to deploy, configure, and manage the Hederium application in Kubernetes clusters.

### Changes
- Created a complete Helm chart structure in the charts/ directory
- Added deployment templates for core Kubernetes resources:
  - Deployment with configurable replicas
  - LoadBalancer Service for external access
  - ConfigMap for application configuration
  - ServiceAccount for pod identity
- Added optional components (disabled by default):
  - HorizontalPodAutoscaler for automatic scaling
  - Ingress for advanced routing
- Created a comprehensive README with deployment instructions
- Configured default values optimized for Minikube development
- Added proper templating to support configuration customization
- Ensured compatibility with the existing Dockerfile and application structure
### Testing
The charts have been tested on Minikube with the following workflow:
1. Building the Docker image in Minikube's Docker environment
2. Installing the chart with default values
3. Accessing the application via LoadBalancer using minikube tunnel
4. Verifying proper configuration through application logs
### Notes
- The default configuration uses a LoadBalancer service type for simplicity
- The charts are designed to work with the existing application configuration in configs/config.yaml
- Resource requests and limits are set to reasonable defaults for local development
- Documentation includes troubleshooting for common issues encountered during testing
This implementation provides a solid foundation for both local development and production deployment of Hederium, with clear separation of configuration from application code.

Fixes #147 