### PR TITLE
feat: add batch requests support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+# Description
+<!-- Provide a brief description of the changes in this PR -->
+
+## Related Issue
+<!-- Link to the issue that this PR addresses. Use the format: Closes #123 -->
+
+## Changes
+<!-- List the main changes made in this PR -->
+
+## Testing
+<!-- Describe how you tested these changes -->
+
+## Checklist
+- [ ] I have performed a self-review of my code
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have updated the documentation accordingly
+- [ ] I have checked my code and corrected any misspellings
+- [ ] My changes generate no new warnings
+- [ ] I have added comments to my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -19,7 +19,7 @@ func main() {
 		fmt.Printf("Failed to load configuration: %v\n", err)
 		return
 	}
-	log := logger.InitLogger("debug")
+	log := logger.InitLogger(viper.GetString("logging.level"))
 	defer log.Sync()
 
 	hClient, err := hedera.NewHederaClient(
@@ -41,10 +41,11 @@ func main() {
 	mClient := hedera.NewMirrorClient(viper.GetString("mirrorNode.baseUrl"), viper.GetInt("mirrorNode.timeoutSeconds"), log, cacheService)
 
 	enforceAPIKey := viper.GetBool("features.enforceApiKey")
+	enableBatchRequests := viper.GetBool("features.enableBatchRequests")
 
 	port := viper.GetString("server.port")
 
-	server := http_server.NewServer(hClient, mClient, log, applicationVersion, chainId, apiKeyStore, tieredLimiter, enforceAPIKey, cacheService, port)
+	server := http_server.NewServer(hClient, mClient, log, applicationVersion, chainId, apiKeyStore, tieredLimiter, enforceAPIKey, enableBatchRequests, cacheService, port)
 	if err := server.Start(); err != nil {
 		log.Fatal("Failed to start server", zap.Error(err))
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LimeChain/Hederium/internal/infrastructure/hedera"
 	"github.com/LimeChain/Hederium/internal/infrastructure/limiter"
 	"github.com/LimeChain/Hederium/internal/infrastructure/logger"
+	"github.com/LimeChain/Hederium/internal/infrastructure/startup"
 	"github.com/LimeChain/Hederium/internal/transport/http_server"
 )
 
@@ -21,6 +22,9 @@ func main() {
 	}
 	log := logger.InitLogger(viper.GetString("logging.level"))
 	defer log.Sync()
+
+	// Log startup information
+	startup.LogStartup()
 
 	hClient, err := hedera.NewHederaClient(
 		viper.GetString("hedera.network"),

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -36,6 +36,7 @@ apiKeys:
 
 features:
   enforceApiKey: false
+  enableBatchRequests: true
 
 cache:
   defaultExpiration: "1h"

--- a/internal/infrastructure/startup/startup.go
+++ b/internal/infrastructure/startup/startup.go
@@ -1,0 +1,78 @@
+package startup
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+const logo = `
+██╗  ██╗███████╗██████╗ ███████╗██████╗ ██╗██╗   ██╗███╗   ███╗
+██║  ██║██╔════╝██╔══██╗██╔════╝██╔══██╗██║██║   ██║████╗ ████║
+███████║█████╗  ██║  ██║█████╗  ██████╔╝██║██║   ██║██╔████╔██║
+██╔══██║██╔══╝  ██║  ██║██╔══╝  ██╔══██╗██║██║   ██║██║╚██╔╝██║
+██║  ██║███████╗██████╔╝███████╗██║  ██║██║╚██████╔╝██║ ╚═╝ ██║
+╚═╝  ╚═╝╚══════╝╚═════╝ ╚══════╝╚═╝  ╚═╝╚═╝ ╚═════╝ ╚═╝     ╚═╝
+`
+
+func LogStartup() {
+	// Print ASCII logo
+	fmt.Println(logo)
+
+	// Print application version
+	version := viper.GetString("application.version")
+	fmt.Printf("Starting Hederium v%s\n\n", version)
+
+	// Print network configuration
+	network := viper.GetString("hedera.network")
+	chainId := viper.GetString("hedera.chainId")
+	fmt.Println("Network Configuration:")
+	fmt.Printf("  Network: %s\n", network)
+	fmt.Printf("  Chain ID: %s\n\n", chainId)
+
+	// Print server configuration
+	port := viper.GetString("server.port")
+	enforceAPIKey := viper.GetBool("features.enforceApiKey")
+	enableBatchRequests := viper.GetBool("features.enableBatchRequests")
+	fmt.Println("Server Configuration:")
+	fmt.Printf("  Port: %s\n", port)
+	fmt.Printf("  Enforce API Key: %v\n", enforceAPIKey)
+	fmt.Printf("  Enable Batch Requests: %v\n\n", enableBatchRequests)
+
+	// Print cache configuration
+	cacheExpiration := viper.GetDuration("cache.defaultExpiration")
+	cacheCleanup := viper.GetDuration("cache.cleanupInterval")
+	fmt.Println("Cache Configuration:")
+	fmt.Printf("  Default Expiration: %s\n", cacheExpiration)
+	fmt.Printf("  Cleanup Interval: %s\n\n", cacheCleanup)
+
+	// Print mirror node configuration
+	mirrorNodeURL := viper.GetString("mirrorNode.baseUrl")
+	mirrorNodeTimeout := viper.GetInt("mirrorNode.timeoutSeconds")
+	fmt.Println("Mirror Node Configuration:")
+	fmt.Printf("  Base URL: %s\n", mirrorNodeURL)
+	fmt.Printf("  Timeout: %d seconds\n\n", mirrorNodeTimeout)
+
+	// Print rate limiting configuration
+	hbarBudget := viper.GetInt("hedera.hbarBudget")
+	fmt.Println("Rate Limiting Configuration:")
+	fmt.Printf("  HBAR Budget: %d\n\n", hbarBudget)
+
+	// Print API keys if present
+	apiKeys := viper.Get("apiKeys")
+	if apiKeys != nil {
+		fmt.Println("API Keys Configuration:")
+		apiKeysSlice, ok := apiKeys.([]interface{})
+		if ok {
+			for i, key := range apiKeysSlice {
+				if keyStr, ok := key.(string); ok {
+					fmt.Printf("  Key %d: %s\n", i+1, strings.Repeat("*", len(keyStr)))
+				}
+			}
+		}
+		fmt.Println()
+	}
+
+	fmt.Println("Starting server...")
+}

--- a/internal/infrastructure/startup/startup.go
+++ b/internal/infrastructure/startup/startup.go
@@ -18,7 +18,7 @@ const logo = `
 
 func LogStartup() {
 	// Print ASCII logo
-	fmt.Println(logo)
+	fmt.Print(logo)
 
 	// Print application version
 	version := viper.GetString("application.version")


### PR DESCRIPTION
## Description
This PR adds support for batch RPC requests in the HTTP server, allowing clients to send multiple JSON-RPC requests in a single HTTP call. The implementation includes parallel processing of requests with proper error handling and rate limiting.

## Changes
- Added batch request handling in HTTP server
- Implemented parallel processing of batch requests using worker pool
- Added rate limiting support for batch requests
- Added configuration option to enable/disable batch requests
- Implemented proper error handling for batch requests
- Added timeout handling for batch processing

## Testing
- Tested parallel processing with various request sizes
- Tested error handling scenarios

Fixed #165 